### PR TITLE
Incompatible with em-http-request 1.0.0

### DIFF
--- a/lib/em-net-http.rb
+++ b/lib/em-net-http.rb
@@ -11,7 +11,7 @@ module EventMachine
       alias_method :msg, :message
     
       def initialize(response_header)
-        @code = response_header.http_status
+        @code = response_header.http_status.to_s
         @message = response_header.http_reason
         @http_version = response_header.http_version
         @header = response_header


### PR DESCRIPTION
Net::HTTP expects a string status code for #response_class, however Eventmachine 1.0's client (which em-http-request depends on) sends back a FixNum.

You can duplicate this bug by changing the gemspec to require em-http-request >= 1.0.0. This fix shouldn't cause any issues with the current minimum version requirements.
