### PR TITLE
Fixed a compatibility issue w/ Faraday using Net::HTTP adapter

### DIFF
--- a/lib/em-net-http.rb
+++ b/lib/em-net-http.rb
@@ -135,7 +135,8 @@ module Net
       headers['content-type'] ||= "application/x-www-form-urlencoded"
 
       t0 = Time.now
-      httpreq = EM::HttpRequest.new(uri).send(req.class::METHOD.downcase.to_sym, opts)
+      request_method = (req.respond_to?(:method) ? req.method : req.class::METHOD).downcase.to_sym
+      httpreq = EM::HttpRequest.new(uri).send(request_method, opts)
 
       f=Fiber.current
 


### PR DESCRIPTION
Fixed a compatibility issue w/ Faraday using Net::HTTP adapter. Faraday creates a Net::HTTPGenericRequest directly (at https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb#L55), which does not have a ::METHOD constant defined, so we have to use #method to get the HTTP method name.
