### PR TITLE
Don't hide errors from EM::HttpRequest

### DIFF
--- a/lib/em-net-http.rb
+++ b/lib/em-net-http.rb
@@ -176,7 +176,7 @@ module Net
           end
           f.resume nhres
         }
-        httpreq.errback {|err|f.resume(:error)}
+        httpreq.errback {|err|f.resume(err)}
 
         nhres = yield_with_error_check(t0)
         nhres.instance_variable_set :@httpreq, httpreq
@@ -185,7 +185,7 @@ module Net
         nhres
       else
         httpreq.callback &convert_em_http_response
-        httpreq.errback {|err|f.resume(:error)}
+        httpreq.errback {|err|f.resume(err)}
 
         yield_with_error_check(t0)
       end
@@ -196,10 +196,7 @@ module Net
     def yield_with_error_check(t0)
       res = Fiber.yield
 
-      if res == :error
-        raise 'EM::HttpRequest error - request timed out' if Time.now - self.read_timeout > t0
-        raise 'EM::HttpRequest error - unknown error'
-      end
+      raise res.error if res.class == EM::HttpClient
 
       res
     end

--- a/spec/em-net-http_spec.rb
+++ b/spec/em-net-http_spec.rb
@@ -1,6 +1,11 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "em-net-http" do
+  around(:each) do |example|
+    Fiber.new do
+      example.run
+    end.resume
+  end
 
   it 'should support streaming the response' do
     assert_identical(:streamed => true) {


### PR DESCRIPTION
I found it strange to hide all the details of the http errors into a generic exception raising an "EM - unknown error".

This PR raises the error from the EM::HttpRequest object instead
